### PR TITLE
fix: support admin pick management

### DIFF
--- a/.env
+++ b/.env
@@ -2,5 +2,12 @@
 # For secret variables is better to use DevServerControl tool with set_env_variable: ["KEY", "SECRET"]
 
 # https://www.builder.io/c/docs/using-your-api-key
+DATABASE_URL=postgres://username:password@host:port/database
+NODE_ENV=development
+PORT=3000
+
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_b3B0aW1hbC13YXJ0aG9nLTQ2LmNsZXJrLmFjY291bnRzLmRldiQ
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_b3B0aW1hbC13YXJ0aG9nLTQ2LmNsZXJrLmFjY291bnRzLmRldiQ
+CLERK_SECRET_KEY=sk_test_FGdWkdd7OoTP6ZRadzhoRb4q1VFRUan4L7c9NPlOmR
 VITE_PUBLIC_BUILDER_KEY=__BUILDER_PUBLIC_KEY__
 PING_MESSAGE="ping pong"

--- a/client/hooks/useUserRoles.ts
+++ b/client/hooks/useUserRoles.ts
@@ -1,4 +1,5 @@
 import { useUser } from "@clerk/clerk-react";
+import { UserPublicMetadata, UserPrivateMetadata } from "@/lib/clerk";
 import { useMemo } from "react";
 
 // Helper function to check user roles
@@ -12,9 +13,13 @@ function hasRole(user: any, role: string): boolean {
 
 export function useUserRoles() {
   const { isSignedIn, user } = useUser();
+  const typedUser = user as unknown as {
+    publicMetadata?: UserPublicMetadata;
+    privateMetadata?: UserPrivateMetadata;
+  };
 
   const roles = useMemo(() => {
-    if (!isSignedIn || !user) {
+    if (!isSignedIn || !typedUser) {
       return {
         isSignedIn: false,
         isAdmin: false,
@@ -24,21 +29,21 @@ export function useUserRoles() {
       };
     }
 
-    const isAdmin = hasRole(user, "admin");
-    const isPremium = hasRole(user, "premium") || isAdmin;
+    const isAdmin = hasRole(typedUser, "admin");
+    const isPremium = hasRole(typedUser, "premium") || isAdmin;
 
     // Get bankroll from private metadata
-    const bankroll = (user.privateMetadata?.bankroll as number) || 0;
+    const bankroll = (typedUser.privateMetadata?.bankroll as number) || 0;
 
     return {
       isSignedIn: true,
       isAdmin,
       isPremium,
-      hasRole: (role: string) => hasRole(user, role),
+      hasRole: (role: string) => hasRole(typedUser, role),
       bankroll,
-      user,
+      user: typedUser as any,
     };
-  }, [isSignedIn, user]);
+  }, [isSignedIn, typedUser]);
 
   return roles;
 }

--- a/client/lib/clerk.ts
+++ b/client/lib/clerk.ts
@@ -1,0 +1,8 @@
+export interface UserPublicMetadata {
+  role?: string;
+  roles?: string[];
+}
+
+export interface UserPrivateMetadata {
+  bankroll?: number;
+}

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { useUser } from "@clerk/clerk-react";
+import { UserPublicMetadata, UserPrivateMetadata } from "@/lib/clerk";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -51,6 +52,7 @@ function hasRole(user: any, role: string): boolean {
 }
 
 interface ExtendedPick extends Pick {
+  tier: "free" | "premium";
   result?: "Pending" | "Win" | "Loss";
   stakePercent?: number;
   analytics?: string;
@@ -58,6 +60,11 @@ interface ExtendedPick extends Pick {
 
 export default function Admin() {
   const { isSignedIn, user } = useUser();
+  const typedUser = user as unknown as {
+    id: string;
+    publicMetadata?: UserPublicMetadata;
+    privateMetadata?: UserPrivateMetadata;
+  };
   const [picks, setPicks] = useState<ExtendedPick[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
@@ -91,7 +98,7 @@ export default function Admin() {
     sportsbook: "DraftKings",
   });
 
-  const isAdmin = isSignedIn && hasRole(user, "admin");
+  const isAdmin = isSignedIn && hasRole(typedUser, "admin");
 
   useEffect(() => {
     if (isAdmin) {
@@ -140,7 +147,7 @@ export default function Admin() {
     try {
       const createData: CreatePickRequest = {
         ...(formData as CreatePickRequest),
-        createdByUserId: user!.id,
+        createdByUserId: typedUser!.id,
       };
 
       const response = await fetch("/api/picks", {

--- a/client/pages/PremiumPicks.tsx
+++ b/client/pages/PremiumPicks.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useUser } from "@clerk/clerk-react";
+import { UserPublicMetadata, UserPrivateMetadata } from "@/lib/clerk";
 import {
   TrendingUp,
   Star,
@@ -51,15 +52,20 @@ function isPremiumUser(user: any): boolean {
 
 export default function PremiumPicks() {
   const { isSignedIn, user } = useUser();
+  const typedUser = user as unknown as {
+    publicMetadata?: UserPublicMetadata;
+    privateMetadata?: UserPrivateMetadata;
+    unsafeMetadata?: Record<string, unknown>;
+  };
   const [expandedPick, setExpandedPick] = useState<string | null>(null);
   const [premiumPicks, setPremiumPicks] = useState<PremiumPick[]>([]);
   const [loading, setLoading] = useState(true);
 
-  const isPremium = isSignedIn && isPremiumUser(user);
+  const isPremium = isSignedIn && isPremiumUser(typedUser);
   const bankroll =
     parseFloat(
-      (user?.privateMetadata?.bankroll ||
-        user?.unsafeMetadata?.bankroll) as string,
+      (typedUser.privateMetadata?.bankroll ||
+        (typedUser as any).unsafeMetadata?.bankroll) as string,
     ) || 0;
 
   useEffect(() => {

--- a/server/routes/picks.ts
+++ b/server/routes/picks.ts
@@ -169,13 +169,32 @@ export const updatePick: RequestHandler = async (req, res) => {
     const { id } = req.params;
     const updates = req.body;
 
-    const updateFields = [];
-    const values = [];
+    const updateFields = [] as string[];
+    const values: any[] = [];
     let paramCount = 1;
+
+    const columnMap: Record<string, string> = {
+      sportCode: "sport_code",
+      gameId: "game_id",
+      propType: "prop_type",
+      propLine: "prop_line",
+      analysisShort: "analysis_short",
+      analysisLong: "analysis_long",
+      confidencePct: "confidence_pct",
+      stakePct: "stake_pct",
+      stakePercent: "stake_pct",
+      odds: "odds",
+      sportsbook: "sportsbook",
+      result: "result",
+      tier: "tier",
+      player: "player",
+      side: "side",
+    };
 
     for (const [key, value] of Object.entries(updates)) {
       if (value !== undefined) {
-        updateFields.push(`${key} = $${paramCount}`);
+        const column = columnMap[key] ?? key;
+        updateFields.push(`${column} = $${paramCount}`);
         values.push(value);
         paramCount++;
       }


### PR DESCRIPTION
## Summary
- add Clerk keys and server config to `.env`
- type Clerk metadata and expose bankroll on client
- map pick updates to database columns to prevent edit errors

## Testing
- `pnpm test`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf58d3c3d0832db71527aed8dca7da