### PR TITLE
fix: allow project root for Vite dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig(({ mode }) => ({
     host: "::",
     port: 8080,
     fs: {
-      allow: ["./client", "./shared"],
+      allow: ["./", "./client", "./shared"],
       deny: [".env", ".env.*", "*.{crt,pem}", "**/.git/**", "server/**"],
     },
   },


### PR DESCRIPTION
## Summary
- allow vite dev server to read from project root preventing 403 errors

## Testing
- `npm test`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68bf6537f678832d857f1e14f4520c09