### PR TITLE
fix: Vite root access and sign-in button

### DIFF
--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -152,12 +152,12 @@ export default function Layout({ children }: LayoutProps) {
               </div>
             ) : (
               <div className="flex items-center space-x-2">
-                <SignInButton mode="modal">
+                <SignInButton mode="modal" asChild>
                   <Button variant="ghost" size="sm">
                     Sign In
                   </Button>
                 </SignInButton>
-                <SignUpButton mode="modal">
+                <SignUpButton mode="modal" asChild>
                   <Button
                     size="sm"
                     className="bg-gradient-to-r from-brand-blue to-brand-purple hover:from-brand-blue/90 hover:to-brand-purple/90"
@@ -231,7 +231,7 @@ export default function Layout({ children }: LayoutProps) {
                         {user?.primaryEmailAddress?.emailAddress}
                       </div>
                     </div>
-                    <SignOutButton>
+                    <SignOutButton asChild>
                       <Button variant="outline" size="sm" className="w-full">
                         Sign Out
                       </Button>
@@ -239,12 +239,12 @@ export default function Layout({ children }: LayoutProps) {
                   </div>
                 ) : (
                   <div className="space-y-2">
-                    <SignInButton mode="modal">
+                    <SignInButton mode="modal" asChild>
                       <Button variant="ghost" size="sm" className="w-full">
                         Sign In
                       </Button>
                     </SignInButton>
-                    <SignUpButton mode="modal">
+                    <SignUpButton mode="modal" asChild>
                       <Button
                         size="sm"
                         className="w-full bg-gradient-to-r from-brand-blue to-brand-purple hover:from-brand-blue/90 hover:to-brand-purple/90"

--- a/client/pages/Settings.tsx
+++ b/client/pages/Settings.tsx
@@ -202,7 +202,7 @@ export default function Settings() {
               </div>
 
               <div className="space-y-3">
-                <SignInButton mode="modal">
+                <SignInButton mode="modal" asChild>
                   <Button
                     size="lg"
                     className="w-full bg-gradient-to-r from-brand-blue to-brand-purple hover:from-brand-blue/90 hover:to-brand-purple/90"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig(({ mode }) => ({
     host: "::",
     port: 8080,
     fs: {
-      allow: ["./client", "./shared"],
+      allow: ["./", "./client", "./shared"],
       deny: [".env", ".env.*", "*.{crt,pem}", "**/.git/**", "server/**"],
     },
   },


### PR DESCRIPTION
## Summary
- allow vite dev server to read from project root preventing 403 errors
- use Clerk auth buttons with `asChild` so custom button works for sign in/out

## Testing
- `pnpm test`
- `pnpm dev`


------
https://chatgpt.com/codex/tasks/task_e_68bf6537f678832d857f1e14f4520c09